### PR TITLE
Make return manifest and lockfile, not just all dependencies (lockfile)

### DIFF
--- a/conda_parser/parse.py
+++ b/conda_parser/parse.py
@@ -1,6 +1,7 @@
 import typing
 
 import yaml
+import re
 from conda.api import Solver
 from yaml import CDumper as Dumper
 from yaml import CLoader as Loader
@@ -30,12 +31,12 @@ def parse_environment(file: typing.BinaryIO) -> dict:
     """
         Loads a file, checks some common error conditions, tries its best
         to see if it is an actual Conda environment.yml file, and if it is,
-        it will return a dictionary of a list of the dependencies and channels.
+        it will return a dictionary of a list of the manifest, lockfile, and channels.
 
         returns
             - dict of "error": "message"
             or
-            - dict of "dependencies", "channels"
+            - dict of "lockfile", "manifest", "channels"
     """
     # we need the `file` field
     if not file:
@@ -56,9 +57,16 @@ def parse_environment(file: typing.BinaryIO) -> dict:
     if not environment.get("dependencies"):
         return {"error": f"No `dependencies:` in your {filename}"}
 
+    # Ignore pip for now.
+    environment["dependencies"] = clean_out_pip(environment["dependencies"])
+
+    lockfile = solve_environment(environment)
+    manifest = resolve_manifest_versions(environment["dependencies"], lockfile)
+
     return {
-        "dependencies": solve_environment(environment),
-        "channels": environment.get("channels", []),
+        "manifest": sorted(manifest, key=lambda i: i["name"]),
+        "lockfile": sorted(lockfile, key=lambda i: i["name"]),
+        "channels": sorted(environment["channels"]),
     }
 
 
@@ -68,13 +76,31 @@ def clean_out_pip(specs: list) -> list:
 
 
 def solve_environment(environment: dict) -> dict:
+    """
+        Using the Conda API, Solve an environment, get back all
+        of the dependencies.
+
+        returns a list of {"name": name, "requirement": requirement} values.
+    """
     prefix = environment.get("prefix", ".")
     channels = environment["channels"]
-    # Ignore pip for now.
-    specs = clean_out_pip(environment["dependencies"])
+    specs = environment["dependencies"]
 
     dependencies = Solver(prefix, channels, specs_to_add=specs).solve_final_state()
 
     return [
         {"name": dep["name"], "requirement": dep["version"]} for dep in dependencies
     ]
+
+
+def resolve_manifest_versions(specs: list, dependencies: list) -> list:
+    """ 
+        This resolves a manifest from what the environment.yml passed in
+        by finding the versions that were Solved        
+
+        returns a list of {"name": name, "requirement": requirement} values.
+    """
+    reg = re.compile(r"([\w\-_\.]+).*?")
+    spec_names = [reg.match(spec).group(0) for spec in specs]
+
+    return [req for req in dependencies if req["name"] in spec_names]

--- a/conda_parser/parse.py
+++ b/conda_parser/parse.py
@@ -100,7 +100,7 @@ def resolve_manifest_versions(specs: list, dependencies: list) -> list:
 
         returns a list of {"name": name, "requirement": requirement} values.
     """
-    reg = re.compile(r"([\w\-_\.]+).*?")
+    reg = re.compile(r"[\w\-\.]+")
     spec_names = [reg.match(spec).group(0) for spec in specs]
 
     return [req for req in dependencies if req["name"] in spec_names]

--- a/conftest.py
+++ b/conftest.py
@@ -53,3 +53,51 @@ def fake_sqlite_deps():
         {"name": "readline", "version": "8.0"},
         {"name": "sqlite", "version": "3.29.0"},
     ]
+
+
+@pytest.fixture
+def package_and_version_strings():
+    return [
+        "_ipyw_jlab_nb_ext_conf=0.1.0=py37_0",
+        "alabaster=0.7.12=py37_0",
+        "anaconda-navigator=1.9.7=py37_0",
+        "asn1crypto=0.24.0=py37_0",
+        "astroid >=2.2.5",
+        "backports.functools_lru_cache=1.5=py_2",
+        "bzip2=1.0.8=h7b6447c_0",
+        "ca-certificates=2019.5.15=0",
+        "conda===4.7.11=py37",
+        "conda-build",
+        "conda-env 2.6.0",
+    ]
+
+
+@pytest.fixture
+def package_and_version_dicts():
+    return [
+        {"name": "_ipyw_jlab_nb_ext_conf", "version": "0.1.0"},
+        {"name": "alabaster", "version": "0.7.12"},
+        {"name": "anaconda-navigator", "version": "1.9.7"},
+        {"name": "asn1crypto", "version": "0.24.0"},
+        {"name": "astroid", "version": "2.2.5"},
+        {"name": "backports.functools_lru_cache", "version": "1.5"},
+        {"name": "blas", "version": "1.0"},
+        {"name": "bleach", "version": "3.1.0"},
+        {"name": "blosc", "version": "1.16.3"},
+        {"name": "bokeh", "version": "1.2.0"},
+        {"name": "boto", "version": "2.49.0"},
+        {"name": "bottleneck", "version": "1.2.1"},
+        {"name": "bzip2", "version": "1.0.8"},
+        {"name": "ca-certificates", "version": "2019.5.15"},
+        {"name": "cairo", "version": "1.14.12"},
+        {"name": "certifi", "version": "2019.6.16"},
+        {"name": "cffi", "version": "1.12.3"},
+        {"name": "chardet", "version": "3.0.4"},
+        {"name": "click", "version": "7.0"},
+        {"name": "cloudpickle", "version": "1.2.1"},
+        {"name": "clyent", "version": "1.2.2"},
+        {"name": "colorama", "version": "0.4.1"},
+        {"name": "conda", "version": "4.7.11"},
+        {"name": "conda-build", "version": "3.18.8"},
+        {"name": "conda-env", "version": "2.6.0"},
+    ]

--- a/tests/test_conda_parser.py
+++ b/tests/test_conda_parser.py
@@ -1,5 +1,3 @@
-import pytest
-
 from conda_parser.parse import (
     FILTER_KEYS,
     allowed_filename,
@@ -7,6 +5,7 @@ from conda_parser.parse import (
     clean_out_pip,
     read_environment,
     solve_environment,
+    resolve_manifest_versions,
 )
 
 
@@ -91,3 +90,28 @@ def test_clean_out_pip():
     """ testing removing pip from specs """
     specs = ["zlib=1.2.11=0", {"pip": ["werkzeug==0.12.2"]}]
     assert clean_out_pip(specs) == ["zlib=1.2.11=0"]
+
+
+def test_resolve_manifest_versions(
+    package_and_version_strings, package_and_version_dicts
+):
+    resolved = resolve_manifest_versions(
+        package_and_version_strings, package_and_version_dicts
+    )
+
+    # Assert at least some change was made
+    assert package_and_version_strings != resolved
+
+    assert resolved == [
+        {"name": "_ipyw_jlab_nb_ext_conf", "version": "0.1.0"},
+        {"name": "alabaster", "version": "0.7.12"},
+        {"name": "anaconda-navigator", "version": "1.9.7"},
+        {"name": "asn1crypto", "version": "0.24.0"},
+        {"name": "astroid", "version": "2.2.5"},
+        {"name": "backports.functools_lru_cache", "version": "1.5"},
+        {"name": "bzip2", "version": "1.0.8"},
+        {"name": "ca-certificates", "version": "2019.5.15"},
+        {"name": "conda", "version": "4.7.11"},
+        {"name": "conda-build", "version": "3.18.8"},
+        {"name": "conda-env", "version": "2.6.0"},
+    ]

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -34,4 +34,4 @@ def test_parse(client, mocker, fake_numpy_deps):
     data = json.loads(response.data)
 
     assert data["channels"] == ["anaconda"]
-    assert {"name": "numpy-base", "requirement": "1.16.4"} in data["dependencies"]
+    assert {"name": "numpy-base", "requirement": "1.16.4"} in data["lockfile"]


### PR DESCRIPTION
example from curling this repo's environment.yml

```json
{
  "channels": [
    "anaconda", 
    "conda-forge", 
    "defaults"
  ], 
  "lockfile": [
    { "name": "ca-certificates", "requirement": "2019.5.15" }, 
    { "name": "libgcc-ng", "requirement": "9.1.0" }, 
    { "name": "libgfortran-ng", "requirement": "7.3.0" }, 
    { "name": "libstdcxx-ng", "requirement": "9.1.0" }, 
    { "name": "bzip2", "requirement": "1.0.8" }, 
    { "name": "expat", "requirement": "2.2.6" }, 
    { "name": "giflib", "requirement": "5.1.4" }, 
    { "name": "icu", "requirement": "58.2" }, 
    { "name": "jpeg", "requirement": "9b" }, 
    { "name": "libffi", "requirement": "3.2.1" }, 
    { "name": "libiconv", "requirement": "1.15" }, 
    { "name": "libuuid", "requirement": "1.0.3" }, 
    { "name": "lz4-c", "requirement": "1.8.1.2" }, 
    { "name": "lzo", "requirement": "2.10" }, 
    { "name": "ncurses", "requirement": "6.1" }, 
    { "name": "openssl", "requirement": "1.1.1" }, 
    { "name": "pcre", "requirement": "8.43" }, 
    { "name": "xz", "requirement": "5.2.4" }, 
    { "name": "yaml", "requirement": "0.1.7" }, 
    { "name": "zlib", "requirement": "1.2.11" }, 
    { "name": "libedit", "requirement": "3.1.20181209" }, 
    { "name": "libpng", "requirement": "1.6.37" }, 
    { "name": "libxml2", "requirement": "2.9.9" }, 
    { "name": "readline", "requirement": "7.0" }, 
    { "name": "tk", "requirement": "8.6.8" }, 
    { "name": "zstd", "requirement": "1.3.7" }, 
    { "name": "freetype", "requirement": "2.9.1" }, 
    { "name": "libarchive", "requirement": "3.3.3" }, 
    { "name": "libtiff", "requirement": "4.0.10" }, 
    { "name": "libxslt", "requirement": "1.1.33" }, 
    { "name": "sqlite", "requirement": "3.29.0" }, 
    { "name": "fontconfig", "requirement": "2.13.0" }, 
    { "name": "libwebp", "requirement": "1.0.1" }, 
    { "name": "python", "requirement": "3.7.4" }, 
    { "name": "appdirs", "requirement": "1.4.3" }, 
    { "name": "asn1crypto", "requirement": "0.24.0" }, 
    { "name": "atomicwrites", "requirement": "1.3.0" }, 
    { "name": "attrs", "requirement": "19.1.0" }, 
    { "name": "certifi", "requirement": "2019.6.16" }, 
    { "name": "chardet", "requirement": "3.0.4" }, 
    { "name": "click", "requirement": "7.0" }, 
    { "name": "coverage", "requirement": "4.5.3" }, 
    { "name": "idna", "requirement": "2.8" }, 
    { "name": "itsdangerous", "requirement": "1.1.0" }, 
    { "name": "libgd", "requirement": "2.2.5" }, 
    { "name": "markupsafe", "requirement": "1.1.1" }, 
    { "name": "more-itertools", "requirement": "7.2.0" }, 
    { "name": "py", "requirement": "1.8.0" }, 
    { "name": "pycosat", "requirement": "0.6.3" }, 
    { "name": "pycparser", "requirement": "2.19" }, 
    { "name": "pyparsing", "requirement": "2.4.0" }, 
    { "name": "pysocks", "requirement": "1.7.0" }, 
    { "name": "python-libarchive-c", "requirement": "2.8" }, 
    { "name": "pyyaml", "requirement": "5.1.1" }, 
    { "name": "ruamel_yaml", "requirement": "0.15.46" }, 
    { "name": "six", "requirement": "1.12.0" }, 
    { "name": "toml", "requirement": "0.10.0" }, 
    { "name": "tqdm", "requirement": "4.32.1" }, 
    { "name": "wcwidth", "requirement": "0.1.7" }, 
    { "name": "werkzeug", "requirement": "0.15.4" }, 
    { "name": "zipp", "requirement": "0.5.2" }, 
    { "name": "black", "requirement": "19.3b0" }, 
    { "name": "cffi", "requirement": "1.12.3" }, 
    { "name": "conda-package-handling", "requirement": "1.3.11" }, 
    { "name": "importlib_metadata", "requirement": "0.19" }, 
    { "name": "nginx", "requirement": "1.15.5" }, 
    { "name": "packaging", "requirement": "19.0" }, 
    { "name": "setuptools", "requirement": "41.0.1" }, 
    { "name": "cryptography", "requirement": "2.7" }, 
    { "name": "gunicorn", "requirement": "19.9.0" }, 
    { "name": "jinja2", "requirement": "2.10.1" }, 
    { "name": "pluggy", "requirement": "0.12.0" }, 
    { "name": "wheel", "requirement": "0.33.4" }, 
    { "name": "flask", "requirement": "1.1.1" }, 
    { "name": "pip", "requirement": "19.1.1" }, 
    { "name": "pyopenssl", "requirement": "19.0.0" }, 
    { "name": "pytest", "requirement": "5.0.1" }, 
    { "name": "pytest-cov", "requirement": "2.7.1" }, 
    { "name": "pytest-flask", "requirement": "0.15.0" }, 
    { "name": "pytest-mock", "requirement": "1.10.4" }, 
    { "name": "urllib3", "requirement": "1.24.2" }, 
    { "name": "requests", "requirement": "2.22.0" }, 
    { "name": "conda", "requirement": "4.7.11" }
  ], 
  "manifest": [
    { "name": "libiconv", "requirement": "1.15" }, 
    { "name": "yaml", "requirement": "0.1.7" }, 
    { "name": "python", "requirement": "3.7.4" }, 
    { "name": "coverage", "requirement": "4.5.3" }, 
    { "name": "pyyaml", "requirement": "5.1.1" }, 
    { "name": "black", "requirement": "19.3b0" }, 
    { "name": "nginx", "requirement": "1.15.5" }, 
    { "name": "gunicorn", "requirement": "19.9.0" }, 
    { "name": "flask", "requirement": "1.1.1" }, 
    { "name": "pip", "requirement": "19.1.1" }, 
    { "name": "pytest", "requirement": "5.0.1" }, 
    { "name": "pytest-cov", "requirement": "2.7.1" }, 
    { "name": "pytest-flask", "requirement": "0.15.0" }, 
    { "name": "pytest-mock", "requirement": "1.10.4" }, 
    { "name": "conda", "requirement": "4.7.11" }
  ]
}
```
