### PR TITLE
Endpoint to get package information

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ python:
 before_install:
   - docker build -t librariesio/conda-parser .
 script:
-  - docker run -it librariesio/conda-parser /bin/sh -c "pytest"
+  - docker run -it librariesio/conda-parser /bin/sh -c "black --check . && pytest"

--- a/conda_parser/__init__.py
+++ b/conda_parser/__init__.py
@@ -13,6 +13,7 @@ def create_app():
 
     @app.route("/info/<channel>/<package>/<version>")
     @app.route("/info/<channel>/<package>", defaults={"version": ""})
+    @app.route("/info/<package>", defaults={"version": "", "channel": "anaconda"})
     def info(channel, package, version):
         return package_info(channel, package, version)
 

--- a/conda_parser/__init__.py
+++ b/conda_parser/__init__.py
@@ -5,6 +5,7 @@ from .info import package_info
 
 from conda.exceptions import ResolvePackageNotFound
 
+
 def create_app():
     app = Flask(__name__)
 
@@ -51,9 +52,11 @@ def create_app():
     def not_found(e):
         # note that we set the 404 status explicitly
         return jsonify(error=404, text=str(e)), 404
+
     app.register_error_handler(404, not_found)
 
     return app
+
 
 def main(debug=False):
     app = create_app()

--- a/conda_parser/__init__.py
+++ b/conda_parser/__init__.py
@@ -17,7 +17,7 @@ def create_app():
     @app.route("/info/<channel>/<package>/<version>")
     def info(channel, package, version):
         try:
-            return package_info(channel, package, version)
+            return jsonify(package_info(channel, package, version)), 200
         except ResolvePackageNotFound:
             abort(404, description=f"Error: {channel}/{package}{version} not found")
 
@@ -45,7 +45,7 @@ def create_app():
             filename = f.filename if hasattr(f, "filename") else f.name
             body = f.read()
 
-        return parse_environment(filename, body)
+        return jsonify(parse_environment(filename, body)), 200
 
     @app.errorhandler(404)
     def not_found(e):

--- a/conda_parser/__init__.py
+++ b/conda_parser/__init__.py
@@ -13,9 +13,8 @@ def create_app():
     def index():
         return "OK"
 
-    @app.route("/info/<channel>/<package>/<version>")
     @app.route("/info/<channel>/<package>", defaults={"version": ""})
-    @app.route("/info/<package>", defaults={"version": "", "channel": "anaconda"})
+    @app.route("/info/<channel>/<package>/<version>")
     def info(channel, package, version):
         try:
             return package_info(channel, package, version)

--- a/conda_parser/__init__.py
+++ b/conda_parser/__init__.py
@@ -11,13 +11,9 @@ def create_app():
     def index():
         return "OK"
 
-    @app.route("/info/<channel>/<package>")
     @app.route("/info/<channel>/<package>/<version>")
-    def info():
-        channel = request.args.get("channel")
-        package = request.args.get("package")
-        version = request.args.get("version", default="")
-
+    @app.route("/info/<channel>/<package>", defaults={"version": ""})
+    def info(channel, package, version):
         return package_info(channel, package, version)
 
     @app.route("/parse", methods=["POST"])

--- a/conda_parser/__init__.py
+++ b/conda_parser/__init__.py
@@ -1,6 +1,7 @@
 from flask import Flask, request
 
 from .parse import parse_environment
+from .info import package_info
 
 
 def create_app():
@@ -9,6 +10,15 @@ def create_app():
     @app.route("/")
     def index():
         return "OK"
+
+    @app.route("/info/<channel>/<package>")
+    @app.route("/info/<channel>/<package>/<version>")
+    def info():
+        channel = request.args.get("channel")
+        package = request.args.get("package")
+        version = request.args.get("version", default="")
+
+        return package_info(channel, package, version)
 
     @app.route("/parse", methods=["POST"])
     def parse():

--- a/conda_parser/info.py
+++ b/conda_parser/info.py
@@ -1,8 +1,25 @@
 from conda.api import Solver
+from conda.exceptions import ResolvePackageNotFound
 
 
 def package_info(channel: str, package: str, version: str) -> dict:
+    # join the package and version together
     spec = f"{package}{version}"
-    packages = Solver(".", [channel], specs_to_add=[spec]).solve_final_state()
-    record = [dep for dep in packages if dep.name == package][0]
-    return dict(record.dump())
+
+    try:
+        # solve the spec for this package.
+        packages = Solver(".", [channel], specs_to_add=[spec]).solve_final_state()
+    except ResolvePackageNotFound:
+        return {"error": f"Errror: {spec} not found"}
+
+    # find the package passed in
+    record = dict([dep for dep in packages if dep.name == package][0].dump())
+
+    # Clear out some unneeded keys
+    del record["arch"]
+    del record["build_number"]
+    del record["constrains"]
+    del record["fn"]
+    del record["subdir"]
+
+    return record

--- a/conda_parser/info.py
+++ b/conda_parser/info.py
@@ -6,11 +6,8 @@ def package_info(channel: str, package: str, version: str) -> dict:
     # join the package and version together
     spec = f"{package}{version}"
 
-    try:
-        # solve the spec for this package.
-        packages = Solver(".", [channel], specs_to_add=[spec]).solve_final_state()
-    except ResolvePackageNotFound:
-        return {"error": f"Errror: {spec} not found"}
+    # solve the spec for this package.
+    packages = Solver(".", [channel], specs_to_add=[spec]).solve_final_state()
 
     # find the package passed in
     record = dict([dep for dep in packages if dep.name == package][0].dump())

--- a/conda_parser/info.py
+++ b/conda_parser/info.py
@@ -8,7 +8,7 @@ def package_info(channel: str, package: str, version: str) -> dict:
     # solve the spec for this package.
     packages = Solver(".", [channel], specs_to_add=[spec]).solve_final_state()
 
-    # find the package passed in
+    # find the package passed in, it will be there, as Solver rasies if not found
     first_package_record = [dep for dep in packages if dep.name == package][0]
     record = dict(first_package_record.dump())
 

--- a/conda_parser/info.py
+++ b/conda_parser/info.py
@@ -12,11 +12,20 @@ def package_info(channel: str, package: str, version: str) -> dict:
     first_package_record = [dep for dep in packages if dep.name == package][0]
     record = dict(first_package_record.dump())
 
-    # Clear out some unneeded keys
-    del record["arch"]
-    del record["build_number"]
-    del record["constrains"]
-    del record["fn"]
-    del record["subdir"]
-
-    return record
+    # Only keep needed keys.
+    KEYS = [
+        "build",
+        "channel",
+        "depends",
+        "license",
+        "license_family",
+        "md5",
+        "name",
+        "platform",
+        "sha256",
+        "size",
+        "timestamp",
+        "url",
+        "version",
+    ]
+    return {k: record[k] for k in KEYS}

--- a/conda_parser/info.py
+++ b/conda_parser/info.py
@@ -1,5 +1,4 @@
 from conda.api import Solver
-from conda.exceptions import ResolvePackageNotFound
 
 
 def package_info(channel: str, package: str, version: str) -> dict:
@@ -10,7 +9,8 @@ def package_info(channel: str, package: str, version: str) -> dict:
     packages = Solver(".", [channel], specs_to_add=[spec]).solve_final_state()
 
     # find the package passed in
-    record = dict([dep for dep in packages if dep.name == package][0].dump())
+    first_package_record = [dep for dep in packages if dep.name == package][0]
+    record = dict(first_package_record.dump())
 
     # Clear out some unneeded keys
     del record["arch"]

--- a/conda_parser/info.py
+++ b/conda_parser/info.py
@@ -1,0 +1,8 @@
+from conda.api import Solver
+
+
+def package_info(channel: str, package: str, version: str) -> dict:
+    spec = f"{package}{version}"
+    packages = Solver(".", [channel], specs_to_add=[spec]).solve_final_state()
+    record = [dep for dep in packages if dep.name == package][0]
+    return dict(record.dump())

--- a/conftest.py
+++ b/conftest.py
@@ -170,6 +170,32 @@ def solved_urllib3():
 
 
 @pytest.fixture
+def expected_result_urllib3():
+    return {
+        "build": "py36_0",
+        "channel": "https://conda.anaconda.org/conda-forge/linux-64",
+        "depends": [
+            "certifi",
+            "cryptography >=1.3.4",
+            "idna >=2.0.0",
+            "pyopenssl >=0.14",
+            "pysocks >=1.5.6,<2.0,!=1.5.7",
+            "python >=3.6,<3.7.0a0",
+        ],
+        "license": "MIT",
+        "license_family": "MIT",
+        "md5": "98696f9f012d04bd7795a6a2febf66a0",
+        "name": "urllib3",
+        "platform": None,
+        "sha256": "d94eb3db911a6806f45a9fba50e49961c189d9fb32c44f8fd19902334616335e",
+        "size": 191254,
+        "timestamp": 1558705030958,
+        "url": "https://conda.anaconda.org/conda-forge/linux-64/urllib3-1.25.3-py36_0.tar.bz2",
+        "version": "1.25.3",
+    }
+
+
+@pytest.fixture
 def record_not_found():
     from conda.exceptions import ResolvePackageNotFound
 

--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,7 @@
 import pytest
 
 from conda_parser import create_app
+from conda.models.records import PackageRecord
 
 
 @pytest.fixture
@@ -101,3 +102,75 @@ def package_and_version_dicts():
         {"name": "conda-build", "version": "3.18.8"},
         {"name": "conda-env", "version": "2.6.0"},
     ]
+
+
+@pytest.fixture
+def solved_urllib3():
+    fake = [
+        PackageRecord(
+            **{
+                "arch": None,
+                "build": "py36_0",
+                "build_number": 0,
+                "channel": "https://conda.anaconda.org/conda-forge/linux-64",
+                "constrains": [],
+                "depends": [
+                    "certifi",
+                    "cryptography >=1.3.4",
+                    "idna >=2.0.0",
+                    "pyopenssl >=0.14",
+                    "pysocks >=1.5.6,<2.0,!=1.5.7",
+                    "python >=3.6,<3.7.0a0",
+                ],
+                "fn": "urllib3-1.25.3-py36_0.tar.bz2",
+                "license": "MIT",
+                "license_family": "MIT",
+                "md5": "98696f9f012d04bd7795a6a2febf66a0",
+                "name": "urllib3",
+                "platform": None,
+                "sha256": "d94eb3db911a6806f45a9fba50e49961c189d9fb32c44f8fd19902334616335e",
+                "size": 191254,
+                "subdir": "linux-64",
+                "timestamp": 1558705030958,
+                "url": "https://conda.anaconda.org/conda-forge/linux-64/urllib3-1.25.3-py36_0.tar.bz2",
+                "version": "1.25.3",
+            }
+        ),
+        PackageRecord(
+            **{
+                "arch": None,
+                "build": "py36_0",
+                "build_number": 0,
+                "channel": "https://conda.anaconda.org/conda-forge/linux-64",
+                "constrains": [],
+                "depends": [
+                    "certifi",
+                    "cryptography >=1.3.4",
+                    "idna >=2.0.0",
+                    "pyopenssl >=0.14",
+                    "pysocks >=1.5.6,<2.0,!=1.5.7",
+                    "python >=3.6,<3.7.0a0",
+                ],
+                "fn": "urllib3-1.25.3-py36_0.tar.bz2",
+                "license": "MIT",
+                "license_family": "MIT",
+                "md5": "98696f9f012d04bd7795a6a2febf66a0",
+                "name": "not-urllib3",
+                "platform": None,
+                "sha256": "d94eb3db911a6806f45a9fba50e49961c189d9fb32c44f8fd19902334616335e",
+                "size": 191254,
+                "subdir": "linux-64",
+                "timestamp": 1558705030958,
+                "url": "https://conda.anaconda.org/conda-forge/linux-64/urllib3-1.25.3-py36_0.tar.bz2",
+                "version": "1.25.3",
+            }
+        ),
+    ]
+    return lambda: fake
+
+
+@pytest.fixture
+def record_not_found():
+    from conda.exceptions import ResolvePackageNotFound
+
+    return (ResolvePackageNotFound(bad_deps=[["whoami"]]),)

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -52,13 +52,6 @@ def test_parse_file(client, mocker, fake_numpy_deps):
 def test_info(client, mocker, solved_urllib3):
     mocker.patch("conda.api.Solver.solve_final_state", side_effect=solved_urllib3)
 
-    # just name
-    response = client.get(url_for("info", package="urllib3"), follow_redirects=True)
-    assert response.status == "200 OK"
-    data = json.loads(response.data)
-
-    assert data["license"] == "MIT"
-
     # name and channel
     response = client.get(
         url_for("info", channel="anaconda", package="urllib3"), follow_redirects=True

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -52,6 +52,17 @@ def test_parse_file(client, mocker, fake_numpy_deps):
 def test_info(client, mocker, solved_urllib3):
     mocker.patch("conda.api.Solver.solve_final_state", side_effect=solved_urllib3)
 
+    # just name
+    response = client.get(
+        url_for("info", package="urllib3"), follow_redirects=True
+    )
+    assert response.status == "200 OK"
+    data = json.loads(response.data)
+
+    assert data["license"] == "MIT"
+
+
+    # name and channel
     response = client.get(
         url_for("info", channel="anaconda", package="urllib3"), follow_redirects=True
     )
@@ -60,10 +71,7 @@ def test_info(client, mocker, solved_urllib3):
 
     assert data["license"] == "MIT"
 
-
-def test_info_version(client, mocker, solved_urllib3):
-    mocker.patch("conda.api.Solver.solve_final_state", side_effect=solved_urllib3)
-
+    # all parameters
     response = client.get(
         url_for("info", channel="anaconda", package="urllib3", version="==1.25.3"),
         follow_redirects=True,
@@ -73,8 +81,8 @@ def test_info_version(client, mocker, solved_urllib3):
 
     assert data["license"] == "MIT"
 
-
-def test_info_version(client, mocker, record_not_found):
+    
+def test_info_error(client, mocker, record_not_found):
     mocker.patch("conda.api.Solver.solve_final_state", side_effect=record_not_found)
 
     response = client.get(

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -49,7 +49,7 @@ def test_parse_file(client, mocker, fake_numpy_deps):
     assert {"name": "numpy-base", "requirement": "1.16.4"} in data["lockfile"]
 
 
-def test_info(client, mocker, solved_urllib3):
+def test_info(client, mocker, solved_urllib3, expected_result_urllib3):
     mocker.patch("conda.api.Solver.solve_final_state", side_effect=solved_urllib3)
 
     # name and channel
@@ -70,6 +70,7 @@ def test_info(client, mocker, solved_urllib3):
     data = json.loads(response.data)
 
     assert data["license"] == "MIT"
+    assert data == expected_result_urllib3
 
 
 def test_info_error(client, mocker, record_not_found):

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -53,14 +53,11 @@ def test_info(client, mocker, solved_urllib3):
     mocker.patch("conda.api.Solver.solve_final_state", side_effect=solved_urllib3)
 
     # just name
-    response = client.get(
-        url_for("info", package="urllib3"), follow_redirects=True
-    )
+    response = client.get(url_for("info", package="urllib3"), follow_redirects=True)
     assert response.status == "200 OK"
     data = json.loads(response.data)
 
     assert data["license"] == "MIT"
-
 
     # name and channel
     response = client.get(
@@ -81,7 +78,7 @@ def test_info(client, mocker, solved_urllib3):
 
     assert data["license"] == "MIT"
 
-    
+
 def test_info_error(client, mocker, record_not_found):
     mocker.patch("conda.api.Solver.solve_final_state", side_effect=record_not_found)
 

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -69,7 +69,6 @@ def test_info(client, mocker, solved_urllib3, expected_result_urllib3):
     assert response.status == "200 OK"
     data = json.loads(response.data)
 
-    assert data["license"] == "MIT"
     assert data == expected_result_urllib3
 
 

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -47,3 +47,40 @@ def test_parse_file(client, mocker, fake_numpy_deps):
 
     assert data["channels"] == ["anaconda"]
     assert {"name": "numpy-base", "requirement": "1.16.4"} in data["lockfile"]
+
+
+def test_info(client, mocker, solved_urllib3):
+    mocker.patch("conda.api.Solver.solve_final_state", side_effect=solved_urllib3)
+
+    response = client.get(
+        url_for("info", channel="anaconda", package="urllib3"), follow_redirects=True
+    )
+    assert response.status == "200 OK"
+    data = json.loads(response.data)
+
+    assert data["license"] == "MIT"
+
+
+def test_info_version(client, mocker, solved_urllib3):
+    mocker.patch("conda.api.Solver.solve_final_state", side_effect=solved_urllib3)
+
+    response = client.get(
+        url_for("info", channel="anaconda", package="urllib3", version="==1.25.3"),
+        follow_redirects=True,
+    )
+    assert response.status == "200 OK"
+    data = json.loads(response.data)
+
+    assert data["license"] == "MIT"
+
+
+def test_info_version(client, mocker, record_not_found):
+    mocker.patch("conda.api.Solver.solve_final_state", side_effect=record_not_found)
+
+    response = client.get(
+        url_for("info", channel="anaconda", package="urllib3", version="==1.25.3"),
+        follow_redirects=True,
+    )
+    assert response.status == "200 OK"
+    data = json.loads(response.data)
+    assert data["error"] == "Errror: urllib3==1.25.3 not found"

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -86,6 +86,8 @@ def test_info_error(client, mocker, record_not_found):
         url_for("info", channel="anaconda", package="urllib3", version="==1.25.3"),
         follow_redirects=True,
     )
-    assert response.status == "200 OK"
     data = json.loads(response.data)
-    assert data["error"] == "Errror: urllib3==1.25.3 not found"
+
+    assert response.status == "404 NOT FOUND"
+    assert data["error"] == 404
+    assert data["text"] == "404 Not Found: Error: anaconda/urllib3==1.25.3 not found"


### PR DESCRIPTION
endpoints are now:

```
info      GET      /info/<channel>/<package>/<version>
info      GET      /info/<channel>/<package>

parse     POST     /parse

index     GET      /
```
channel defaults to `anaconda`. is this the default channel? or should it be `defaults`



```
$ curl http://localhost:5000/info/anaconda/urllib3/==1.25.3 | python -m json.tool

{
    "build": "py37_0",
    "channel": "https://conda.anaconda.org/anaconda/linux-64",
    "depends": [
        "certifi",
        "cryptography >=1.3.4",
        "idna >=2.0.0",
        "pyopenssl >=0.14",
        "pysocks >=1.5.6,<2.0,!=1.5.7",
        "python >=3.7,<3.8.0a0"
    ],
    "license": "MIT",
    "license_family": "MIT",
    "md5": "f06fbed3e6bb1f09c4e6e3ec283086e0",
    "name": "urllib3",
    "platform": null,
    "sha256": "7495543552e05227acedf06269c5c17127adb1e832ba20c82228663781859d7b",
    "size": 196212,
    "timestamp": 1559849559862,
    "url": "https://conda.anaconda.org/anaconda/linux-64/urllib3-1.25.3-py37_0.tar.bz2",
    "version": "1.25.3"
}
```
also: 
Closes #8 