### PR TITLE
Error handling for Parser

### DIFF
--- a/conda_parser/__init__.py
+++ b/conda_parser/__init__.py
@@ -16,10 +16,7 @@ def create_app():
     @app.route("/info/<channel>/<package>", defaults={"version": ""})
     @app.route("/info/<channel>/<package>/<version>")
     def info(channel, package, version):
-        try:
-            return jsonify(package_info(channel, package, version)), 200
-        except ResolvePackageNotFound:
-            abort(404, description=f"Error: {channel}/{package}{version} not found")
+        return jsonify(package_info(channel, package, version)), 200
 
     @app.route("/parse", methods=["POST"])
     def parse():
@@ -45,16 +42,12 @@ def create_app():
             filename = f.filename if hasattr(f, "filename") else f.name
             body = f.read()
 
-        try:
-            return jsonify(parse_environment(filename, body)), 200
-        except ResolvePackageNotFound as e:
-            abort(404, description=f"Error: Package(s) not found: {e}")
+        return jsonify(parse_environment(filename, body)), 200
 
-    @app.errorhandler(404)
+    @app.errorhandler(ResolvePackageNotFound)
     def not_found(e):
-        return jsonify(error=404, text=str(e)), 404
-
-    app.register_error_handler(404, not_found)
+        message = f"Error: Package(s) not found: {e}"
+        return jsonify(error=404, text=message), 404
 
     return app
 

--- a/conda_parser/__init__.py
+++ b/conda_parser/__init__.py
@@ -4,7 +4,6 @@ from .parse import parse_environment
 from .info import package_info
 
 from conda.exceptions import ResolvePackageNotFound
-from conda import CondaError
 
 
 def create_app():

--- a/conda_parser/__init__.py
+++ b/conda_parser/__init__.py
@@ -48,19 +48,14 @@ def create_app():
 
         try:
             return jsonify(parse_environment(filename, body)), 200
-        except CondaError as e:
-            abort(500, description=f"Error parsing environment: {e}")
+        except ResolvePackageNotFound as e:
+            abort(404, description=f"Error: Package(s) not found: {e}")
 
     @app.errorhandler(404)
     def not_found(e):
         return jsonify(error=404, text=str(e)), 404
 
-    @app.errorhandler(500)
-    def not_found(e):
-        return jsonify(error=500, text=str(e)), 500
-
     app.register_error_handler(404, not_found)
-    app.register_error_handler(500, not_found)
 
     return app
 

--- a/conftest.py
+++ b/conftest.py
@@ -199,4 +199,4 @@ def expected_result_urllib3():
 def record_not_found():
     from conda.exceptions import ResolvePackageNotFound
 
-    return (ResolvePackageNotFound(bad_deps=[["whoami"]]),)
+    return (ResolvePackageNotFound(bad_deps=[["whoami","==1.25.3"]]),)

--- a/conftest.py
+++ b/conftest.py
@@ -199,4 +199,4 @@ def expected_result_urllib3():
 def record_not_found():
     from conda.exceptions import ResolvePackageNotFound
 
-    return (ResolvePackageNotFound(bad_deps=[["whoami","==1.25.3"]]),)
+    return (ResolvePackageNotFound(bad_deps=[["whoami", "==1.25.3"]]),)

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -60,7 +60,7 @@ def test_parse_file_not_found(client, mocker, record_not_found):
     assert response.status == "404 NOT FOUND"
     assert json.loads(response.data) == {
         "error": 404,
-        "text": "404 Not Found: Error: Package(s) not found: \n  - whoami",
+        "text": "Error: Package(s) not found: \n  - whoami -> ==1.25.3",
     }
 
 
@@ -91,11 +91,11 @@ def test_info_error(client, mocker, record_not_found):
     mocker.patch("conda.api.Solver.solve_final_state", side_effect=record_not_found)
 
     response = client.get(
-        url_for("info", channel="anaconda", package="urllib3", version="==1.25.3"),
+        url_for("info", channel="anaconda", package="whoami", version="==1.25.3"),
         follow_redirects=True,
     )
     data = json.loads(response.data)
 
     assert response.status == "404 NOT FOUND"
     assert data["error"] == 404
-    assert data["text"] == "404 Not Found: Error: anaconda/urllib3==1.25.3 not found"
+    assert data["text"] == "Error: Package(s) not found: \n  - whoami -> ==1.25.3"

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -52,15 +52,15 @@ def test_parse_file(client, mocker, fake_numpy_deps):
     assert {"name": "numpy-base", "requirement": "1.16.4"} in data["lockfile"]
 
 
-def test_parse_file_error(client, mocker, record_not_found):
+def test_parse_file_not_found(client, mocker, record_not_found):
     """ testing parsing POST """
     mocker.patch("conda.api.Solver.solve_final_state", side_effect=record_not_found)
 
     response = _post_urlencoded(client, "tests/fixtures/just_numpy.yml", "parse")
-    assert response.status == "500 INTERNAL SERVER ERROR"
+    assert response.status == "404 NOT FOUND"
     assert json.loads(response.data) == {
-        "error": 500,
-        "text": "500 Internal Server Error: Error parsing environment: \n  - whoami",
+        "error": 404,
+        "text": "404 Not Found: Error: Package(s) not found: \n  - whoami",
     }
 
 


### PR DESCRIPTION
Adds some error handling for the parser as well. Returning a 404 error

Seems Flask style is to add error handling around an exception, not abort to throw an HTTP code and catch around that.