### PR TITLE
Allow None for key value

### DIFF
--- a/conda_parser/info.py
+++ b/conda_parser/info.py
@@ -31,7 +31,7 @@ def package_info(channel: str, package: str, version: str) -> dict:
         "url",
         "version",
     ]
-    return {k: record[k] for k in KEYS}
+    return {k: record.get(k) for k in KEYS}
 
 
 def unquote_params(*args: str) -> list:


### PR DESCRIPTION
Apparently from Conda, all keys aren't returned every time.

this fixes
```
File "/app/conda_parser/info.py", line 34, in <dictcomp>
    return {k: record[k] for k in KEYS}
KeyError: 'license_family'
```

I want to explicitly keep the `null` value, so that the data shape looks the same every time.. Unlike this api I'm consuming that seems to remove null valued keys.

