### PR TITLE
Remove Conda-Forge

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,6 @@
 name: conda-parser
 channels:
-  - anaconda
-  - conda-forge
+  - defaults
 dependencies:
   - black
   - conda
@@ -12,9 +11,10 @@ dependencies:
   - nginx
   - pip
   - pytest
-  - pytest-flask
   - pytest-mock
   - pytest-cov
   - python=3.7.4
   - pyyaml
   - yaml
+  - pip:
+    - pytest-flask


### PR DESCRIPTION
This speeds things up, we only needed conda-forge for pytest-flask, which we can get from pip