### PR TITLE
Split manifest and lockfile responses, but still allow a force of both if you don't provide a lockfile

### DIFF
--- a/conda_parser/__init__.py
+++ b/conda_parser/__init__.py
@@ -40,9 +40,15 @@ def create_app():
                 application/x-www-form-urlencoded:
                     file: the text of the environment file
                     filename: the filename (needs to be .yml or .yaml)
+            Query Parameters:
+                [force_solve=1]
+                    existance of any value will cause this flag to be set and solve
+                    whethere there is a lock file or not.
             Returns:
                 json with "error" or with "dependencies"/"channels"
         """
+        force_solve = bool(request.args.get("force_solve", False))
+
         # get the file from either files or form
         if request.content_type.startswith("application/x-www-form-urlencoded"):
             body = request.form.get("file")
@@ -52,7 +58,6 @@ def create_app():
             filename = f.filename if hasattr(f, "filename") else f.name
             body = f.read()
 
-        force_solve = bool(request.args.get("force_solve", False))
         return jsonify(parse_environment(filename, body, force_solve)), 200
 
     @app.errorhandler(ResolvePackageNotFound)

--- a/conda_parser/__init__.py
+++ b/conda_parser/__init__.py
@@ -43,7 +43,7 @@ def create_app():
             Query Parameters:
                 [force_solve=1]
                     existance of any value will cause this flag to be set and solve
-                    whethere there is a lock file or not.
+                    whether there is a lock file or not.
             Returns:
                 json with "error" or with "dependencies"/"channels"
         """

--- a/conda_parser/__init__.py
+++ b/conda_parser/__init__.py
@@ -52,7 +52,8 @@ def create_app():
             filename = f.filename if hasattr(f, "filename") else f.name
             body = f.read()
 
-        return jsonify(parse_environment(filename, body)), 200
+        force_solve = bool(request.args.get("force_solve", False))
+        return jsonify(parse_environment(filename, body, force_solve)), 200
 
     @app.errorhandler(ResolvePackageNotFound)
     def not_found(e):

--- a/conda_parser/parse.py
+++ b/conda_parser/parse.py
@@ -111,12 +111,15 @@ def parse_environment(
 
     if force_solve or is_lock(filename):
         lockfile, bad_specs = solve_environment(environment)
+        # Sort the lockfile
+        lockfile = sorted(lockfile, key=lambda i: i.get("name", ""))
     else:
-        lockfile, bad_specs = [], []
+        lockfile = None
+        bad_specs = []
 
     output = {
         "manifest": sorted(manifest, key=lambda i: i.get("name", "")),
-        "lockfile": sorted(lockfile, key=lambda i: i.get("name", "")),
+        "lockfile": lockfile,
         "channels": environment["channels"],
         "bad_specs": sorted(bad_specs),
     }

--- a/environment.yml.lock
+++ b/environment.yml.lock
@@ -1,0 +1,20 @@
+name: conda-parser
+channels:
+  - defaults
+dependencies:
+  - black
+  - conda
+  - coverage
+  - flask
+  - gunicorn
+  - libiconv
+  - nginx
+  - pip
+  - pytest
+  - pytest-mock
+  - pytest-cov
+  - python=3.7.4
+  - pyyaml
+  - yaml
+  - pip:
+    - pytest-flask

--- a/tests/fixtures/numpy.yml.lock
+++ b/tests/fixtures/numpy.yml.lock
@@ -1,0 +1,5 @@
+name: numpy-lock
+channels:
+  - anaconda
+dependencies:
+  - numpy 1.16.4

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -32,7 +32,7 @@ def _post(client, data, view, content_type, force_solve=True):
     return client.post(url, data=data, follow_redirects=True, content_type=content_type)
 
 
-def test_parse_file(client, mocker, fake_numpy_deps):
+def test_parse_file_force(client, mocker, fake_numpy_deps):
     """ testing parsing POST """
     mocker.patch("conda.api.Solver.solve_final_state", side_effect=fake_numpy_deps)
 
@@ -72,6 +72,7 @@ def test_parse_file_no_force_lockfile(client, mocker, fake_numpy_deps):
     data = json.loads(response.data)
 
     assert data["channels"] == ["anaconda", "defaults"]
+    assert {"name": "numpy", "requirement": "1.16.4"} in data["manifest"]
     assert {"name": "numpy-base", "requirement": "1.16.4"} in data["lockfile"]
 
 

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -58,7 +58,7 @@ def test_parse_file_no_force(client, mocker, fake_numpy_deps):
     data = json.loads(response.data)
 
     assert data["channels"] == ["anaconda", "defaults"]
-    assert data["lockfile"] == []
+    assert data["lockfile"] == None
     assert data["manifest"] == [{"name": "numpy", "requirement": "1.16.4"}]
 
 
@@ -76,7 +76,7 @@ def test_parse_file_no_force_lockfile(client, mocker, fake_numpy_deps):
     assert {"name": "numpy-base", "requirement": "1.16.4"} in data["lockfile"]
 
 
-def test_parse_file_not_found(client, mocker, record_not_found):
+def test_parse_not_found_force(client, mocker, record_not_found):
     """ testing parsing POST """
     mocker.patch(
         "conda.api.Solver.solve_final_state", side_effect=[record_not_found, []]


### PR DESCRIPTION
This adds a new query parameter to `parse`:  "?force_solve"
it's existence/nonexistence based.


Splitting `environment.yml` and `environment.yml.lock` in conda-parser 
![](https://tyrelsouza.com/screenshots/104340dd42958431716de8fb80e69406.png)
